### PR TITLE
Minimal PHP Version is now 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
   ci:
     uses: codenamephp/workflows.php/.github/workflows/ci.yml@1
     with:
-      php-versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["8.2", "8.3"]'

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -146,7 +146,7 @@
       </interpreter>
     </phpInfoCache>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.0" />
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.2" />
   <component name="PhpStanOptionsConfiguration">
     <option name="transferred" value="true" />
   </component>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.2",
     "twig/twig": "^3.0",
     "symfony/filesystem": "^6.0"
   },
@@ -41,8 +41,8 @@
     "phpunit": "XDEBUG_MODE=coverage tools/phpunit.phar -c test/phpunit.dist.xml test/",
     "psalm": "XDEBUG_MODE=off tools/psalm --threads=10 --long-progress",
     "composer-unused": "XDEBUG_MODE=off tools/composer-unused --no-progress --no-interaction",
-    "composer-require-checker": "php -r 'exit((int) !(PHP_VERSION_ID >= 80400));' && XDEBUG_MODE=off tools/composer-require-checker --no-interaction || echo 'Skipping composer-require-checker because it needs PHP8.2 or higher'",
-    "infection": "php -r 'exit((int) !(PHP_VERSION_ID >= 80100));' && XDEBUG_MODE=coverage tools/infection --min-msi=100 --min-covered-msi=100 --threads=4 --no-progress --show-mutations || echo 'Skipping infection because it needs PHP8.1 or higher'",
+    "composer-require-checker": "XDEBUG_MODE=off tools/composer-require-checker --no-interaction",
+    "infection": "XDEBUG_MODE=coverage tools/infection --min-msi=100 --min-covered-msi=100 --threads=4 --no-progress --show-mutations",
     "phive:update": "XDEBUG_MODE=off phive update && git add tools/* phive.xml && git commit tools/* -m 'Updated phive dependencies'",
     "ci-all": [
       "composer validate",


### PR DESCRIPTION
PHP8.1 is EOL and tools like infection and composer-require-checker stopped supporting those. Since I don't want to dance around them I drop them as well.